### PR TITLE
Fixed reception of PINGRESP messages

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -1575,7 +1575,8 @@ struct mqtt_queued_message* mqtt_mq_find(struct mqtt_message_queue *mq, enum MQT
     struct mqtt_queued_message *curr;
     for(curr = mqtt_mq_get(mq, 0); curr >= mq->queue_tail; --curr) {
         if (curr->control_type == control_type) {
-            if (packet_id == NULL || (packet_id != NULL && *packet_id == curr->packet_id)) {
+            if ((packet_id == NULL && curr->state != MQTT_QUEUED_COMPLETE) ||
+                (packet_id != NULL && *packet_id == curr->packet_id)) {
                 return curr;
             }
         }


### PR DESCRIPTION
On receiving a `PINGRESP` is only released the associated `PINREQ `(state message != `MQTT_QUEUED_COMPLETE`, probably in `MQTT_QUEUED_AWAITING_ACK `state)