### PR TITLE
double decl-spec and fixed-header "remaining length" pack/unpack fixes

### DIFF
--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -164,6 +164,7 @@ struct mqtt_fixed_header {
     MQTT_ERROR(MQTT_ERROR_SUBSCRIBE_FAILED)              \
     MQTT_ERROR(MQTT_ERROR_CONNECTION_CLOSED)             \
     MQTT_ERROR(MQTT_ERROR_INITIAL_RECONNECT)             \
+    MQTT_ERROR(MQTT_ERROR_INVALID_REMAINING_LENGTH)
 
 /* todo: add more connection refused errors */
 

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -919,6 +919,11 @@ ssize_t mqtt_unpack_fixed_header(struct mqtt_response *response, const uint8_t *
 
     lshift = 0;
     do {
+
+        /* MQTT spec (2.2.3) says the maximum length is 28 bits */
+        if(lshift == 28)
+            return MQTT_ERROR_INVALID_REMAINING_LENGTH;
+
         /* consume byte and assert at least 1 byte left */
         --bufsz;
         ++buf;
@@ -972,6 +977,11 @@ ssize_t mqtt_pack_fixed_header(uint8_t *buf, size_t bufsz, const struct mqtt_fix
     *buf |= ((uint8_t) fixed_header->control_flags)       & 0x0F;
 
     remaining_length = fixed_header->remaining_length;
+
+    /* MQTT spec (2.2.3) says maximum remaining length is 2^28-1 */
+    if(remaining_length >= 256*1024*1024)
+        return MQTT_ERROR_INVALID_REMAINING_LENGTH;
+
     do {
         /* consume byte and assert at least 1 byte left */
         --bufsz;

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -1010,7 +1010,7 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
 { 
     struct mqtt_fixed_header fixed_header;
     uint32_t remaining_length;
-    const uint8_t const* start = buf;
+    const uint8_t *const start = buf;
     ssize_t rv;
     uint8_t temp;
 
@@ -1119,7 +1119,7 @@ ssize_t mqtt_pack_connection_request(uint8_t* buf, size_t bufsz,
 
 /* CONNACK */
 ssize_t mqtt_unpack_connack_response(struct mqtt_response *mqtt_response, const uint8_t *buf) {
-    const uint8_t const *start = buf;
+    const uint8_t *const start = buf;
     struct mqtt_response_connack *response;
 
     /* check that remaining length is 2 */
@@ -1171,7 +1171,7 @@ ssize_t mqtt_pack_publish_request(uint8_t *buf, size_t bufsz,
                                   size_t application_message_size,
                                   uint8_t publish_flags)
 {
-    const uint8_t const *start = buf;
+    const uint8_t *const start = buf;
     ssize_t rv;
     struct mqtt_fixed_header fixed_header;
     uint16_t remaining_length;
@@ -1237,7 +1237,7 @@ ssize_t mqtt_pack_publish_request(uint8_t *buf, size_t bufsz,
 
 ssize_t mqtt_unpack_publish_response(struct mqtt_response *mqtt_response, const uint8_t *buf)
 {    
-    const uint8_t const *start = buf;
+    const uint8_t *const start = buf;
     struct mqtt_fixed_header *fixed_header;
     struct mqtt_response_publish *response;
     
@@ -1283,7 +1283,7 @@ ssize_t mqtt_pack_pubxxx_request(uint8_t *buf, size_t bufsz,
                                  enum MQTTControlPacketType control_type,
                                  uint16_t packet_id) 
 {
-    const uint8_t const *start = buf;
+    const uint8_t *const start = buf;
     struct mqtt_fixed_header fixed_header;
     ssize_t rv;
     if (buf == NULL) {
@@ -1317,7 +1317,7 @@ ssize_t mqtt_pack_pubxxx_request(uint8_t *buf, size_t bufsz,
 
 ssize_t mqtt_unpack_pubxxx_response(struct mqtt_response *mqtt_response, const uint8_t *buf) 
 {
-    const uint8_t const *start = buf;
+    const uint8_t *const start = buf;
     uint16_t packet_id;
 
     /* assert remaining length is correct */
@@ -1344,7 +1344,7 @@ ssize_t mqtt_unpack_pubxxx_response(struct mqtt_response *mqtt_response, const u
 
 /* SUBACK */
 ssize_t mqtt_unpack_suback_response (struct mqtt_response *mqtt_response, const uint8_t *buf) {
-    const uint8_t const *start = buf;
+    const uint8_t *const start = buf;
     uint32_t remaining_length = mqtt_response->fixed_header.remaining_length;
     
     /* assert remaining length is at least 3 (for packet id and at least 1 topic) */
@@ -1368,7 +1368,7 @@ ssize_t mqtt_unpack_suback_response (struct mqtt_response *mqtt_response, const 
 /* SUBSCRIBE */
 ssize_t mqtt_pack_subscribe_request(uint8_t *buf, size_t bufsz, uint16_t packet_id, ...) {
     va_list args;
-    const uint8_t const *start = buf;
+    const uint8_t *const start = buf;
     ssize_t rv;
     struct mqtt_fixed_header fixed_header;
     unsigned int num_subs = 0;
@@ -1433,7 +1433,7 @@ ssize_t mqtt_pack_subscribe_request(uint8_t *buf, size_t bufsz, uint16_t packet_
 /* UNSUBACK */
 ssize_t mqtt_unpack_unsuback_response(struct mqtt_response *mqtt_response, const uint8_t *buf) 
 {
-    const uint8_t const *start = buf;
+    const uint8_t *const start = buf;
 
     if (mqtt_response->fixed_header.remaining_length != 2) {
         return MQTT_ERROR_MALFORMED_RESPONSE;
@@ -1449,7 +1449,7 @@ ssize_t mqtt_unpack_unsuback_response(struct mqtt_response *mqtt_response, const
 /* UNSUBSCRIBE */
 ssize_t mqtt_pack_unsubscribe_request(uint8_t *buf, size_t bufsz, uint16_t packet_id, ...) {
     va_list args;
-    const uint8_t const *start = buf;
+    const uint8_t *const start = buf;
     ssize_t rv;
     struct mqtt_fixed_header fixed_header;
     unsigned int num_subs = 0;
@@ -1587,7 +1587,7 @@ struct mqtt_queued_message* mqtt_mq_find(struct mqtt_message_queue *mq, enum MQT
 
 /* RESPONSE UNPACKING */
 ssize_t mqtt_unpack_response(struct mqtt_response* response, const uint8_t *buf, size_t bufsz) {
-    const uint8_t const *start = buf;
+    const uint8_t *const start = buf;
     ssize_t rv = mqtt_unpack_fixed_header(response, buf, bufsz);
     if (rv <= 0) return rv;
     else buf += rv;


### PR DESCRIPTION
switched instances of "const T const *start = buf" to "const T *const start = buf", as that appears to be the intent