### PR TITLE
Adds custom pointer for mqtt_client, option to pass client to pal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 bin/
+nbproject

--- a/examples/pal_client_ref.c
+++ b/examples/pal_client_ref.c
@@ -1,0 +1,200 @@
+
+/**
+ * @file
+ * A copy of simple-publisher, but the pal functions contain a reference to the client.
+ * Can be used to link the client to some custom data (client->custom) needed for sending and receiving. 
+ * MQTT_USE_CUSTOM_PAL_PTR must be defined.
+ */
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <mqtt.h>
+#include "templates/posix_sockets.h"
+
+
+#include <errno.h>
+
+/**
+ * Default pal send function but with additional client reference (struct mqtt_client*)
+ */
+ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags, void* client) {
+    struct mqtt_client* c = client; /* get mqtt_client */
+    char* customString = c->custom; /* for example: a custom string */
+    size_t sent = 0;
+    while(sent < len) {
+        ssize_t tmp = send(fd, buf + sent, len - sent, flags);
+        if (tmp < 1) {
+            return MQTT_ERROR_SOCKET_ERROR;
+        }
+        sent += (size_t) tmp;
+    }
+    return sent;
+}
+
+/**
+ * Default pal recv function but with additional client reference (struct mqtt_client*)
+ */
+ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags, void* client) {
+    const void const *start = buf;
+    ssize_t rv;
+    do {
+        rv = recv(fd, buf, bufsz, flags);
+        if (rv > 0) {
+            /* successfully read bytes from the socket */
+            buf += rv;
+            bufsz -= rv;
+        } else if (rv < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+            /* an error occurred that wasn't "nothing to read". */
+            return MQTT_ERROR_SOCKET_ERROR;
+        }
+    } while (rv > 0);
+
+    return buf - start;
+}
+
+
+/**
+ * @brief The function that would be called whenever a PUBLISH is received.
+ * 
+ * @note This function is not used in this example. 
+ */
+void publish_callback(void** unused, struct mqtt_response_publish *published);
+
+/**
+ * @brief The client's refresher. This function triggers back-end routines to 
+ *        handle ingress/egress traffic to the broker.
+ * 
+ * @note All this function needs to do is call \ref __mqtt_recv and 
+ *       \ref __mqtt_send every so often. I've picked 100 ms meaning that 
+ *       client ingress/egress traffic will be handled every 100 ms.
+ */
+void* client_refresher(void* client);
+
+/**
+ * @brief Safelty closes the \p sockfd and cancels the \p client_daemon before \c exit. 
+ */
+void exit_example(int status, int sockfd, pthread_t *client_daemon);
+
+/**
+ * A simple program to that publishes the current time whenever ENTER is pressed. 
+ */
+int main(int argc, const char *argv[]) 
+{
+    const char* addr;
+    const char* port;
+    const char* topic;
+
+    /* get address (argv[1] if present) */
+    if (argc > 1) {
+        addr = argv[1];
+    } else {
+        addr = "test.mosquitto.org";
+    }
+
+    /* get port number (argv[2] if present) */
+    if (argc > 2) {
+        port = argv[2];
+    } else {
+        port = "1883";
+    }
+
+    /* get the topic name to publish */
+    if (argc > 3) {
+        topic = argv[3];
+    } else {
+        topic = "datetime";
+    }
+
+    /* open the non-blocking TCP socket (connecting to the broker) */
+    int sockfd = open_nb_socket(addr, port);
+
+    if (sockfd == -1) {
+        perror("Failed to open socket: ");
+        exit_example(EXIT_FAILURE, sockfd, NULL);
+    }
+
+    /* setup a client */
+    struct mqtt_client client;
+   
+    /* store some custom data in the client struct for later use. Can also be used in pal. */
+    char* id = "CustomIdString";
+    client.custom = id;
+    
+    uint8_t sendbuf[2048]; /* sendbuf should be large enough to hold multiple whole mqtt messages */
+    uint8_t recvbuf[1024]; /* recvbuf should be large enough any whole mqtt message expected to be received */
+    mqtt_init(&client, sockfd, sendbuf, sizeof(sendbuf), recvbuf, sizeof(recvbuf), publish_callback);
+    mqtt_connect(&client, "publishing_client", NULL, NULL, 0, NULL, NULL, 0, 400);
+
+    /* check that we don't have any errors */
+    if (client.error != MQTT_OK) {
+        fprintf(stderr, "error: %s\n", mqtt_error_str(client.error));
+        exit_example(EXIT_FAILURE, sockfd, NULL);
+    }
+
+    /* start a thread to refresh the client (handle egress and ingree client traffic) */
+    pthread_t client_daemon;
+    if(pthread_create(&client_daemon, NULL, client_refresher, &client)) {
+        fprintf(stderr, "Failed to start client daemon.\n");
+        exit_example(EXIT_FAILURE, sockfd, NULL);
+
+    }
+
+    /* start publishing the time */
+    printf("%s is ready to begin publishing the time.\n", argv[0]);
+    printf("Press ENTER to publish the current time.\n");
+    printf("Press CTRL-D (or any other key) to exit.\n\n");
+    while(fgetc(stdin) == '\n') {
+        /* get the current time */
+        time_t timer;
+        time(&timer);
+        struct tm* tm_info = localtime(&timer);
+        char timebuf[26];
+        strftime(timebuf, 26, "%Y-%m-%d %H:%M:%S", tm_info);
+
+        /* print a message */
+        char application_message[256];
+        snprintf(application_message, sizeof(application_message), "The time is %s", timebuf);
+        printf("%s published : \"%s\"", argv[0], application_message);
+
+        /* publish the time */
+        mqtt_publish(&client, topic, application_message, strlen(application_message) + 1, MQTT_PUBLISH_QOS_0);
+
+        /* check for errors */
+        if (client.error != MQTT_OK) {
+            fprintf(stderr, "error: %s\n", mqtt_error_str(client.error));
+            exit_example(EXIT_FAILURE, sockfd, &client_daemon);
+        }
+    }   
+
+    /* disconnect */
+    printf("\n%s disconnecting from %s\n", argv[0], addr);
+    sleep(1);
+
+    /* exit */ 
+    exit_example(EXIT_SUCCESS, sockfd, &client_daemon);
+}
+
+void exit_example(int status, int sockfd, pthread_t *client_daemon)
+{
+    if (sockfd != -1) close(sockfd);
+    if (client_daemon != NULL) pthread_cancel(*client_daemon);
+    exit(status);
+}
+
+
+
+void publish_callback(void** unused, struct mqtt_response_publish *published) 
+{
+    /* not used in this example */
+}
+
+void* client_refresher(void* client)
+{
+    while(1) 
+    {
+        mqtt_sync((struct mqtt_client*) client);
+        usleep(100000U);
+    }
+    return NULL;
+}

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -1158,6 +1158,11 @@ struct mqtt_client {
 
     /** @brief The sending message queue. */
     struct mqtt_message_queue mq;
+    
+#ifdef MQTT_USE_CUSTOM_PAL_PTR
+    /** @brief A custom pointer to store additional info and states for each client. */
+    void* custom;
+#endif
 };
 
 /**

--- a/include/mqtt_pal.h
+++ b/include/mqtt_pal.h
@@ -80,8 +80,11 @@
  * 
  * @returns The number of bytes sent if successful, an \ref MQTTErrors otherwise.
  */
+#ifdef MQTT_USE_CUSTOM_PAL_PTR
+ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags, void* client);
+#else
 ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags);
-
+#endif
 /**
  * @brief Non-blocking receive all the byte available.
  * @ingroup pal
@@ -93,6 +96,10 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
  * 
  * @returns The number of bytes received if successful, an \ref MQTTErrors otherwise.
  */
+#ifdef MQTT_USE_CUSTOM_PAL_PTR
+ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags, void* client);
+#else
 ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags);
+#endif
 
 #endif

--- a/makefile
+++ b/makefile
@@ -1,9 +1,9 @@
 
 CC = gcc
-CFLAGS = -Wextra -Wall -std=gnu99 -Iinclude -Wno-unused-parameter -Wno-unused-variable -Wno-duplicate-decl-specifier
+CFLAGS = -g -Wextra -Wall -std=gnu99 -Iinclude -Wno-unused-parameter -Wno-unused-variable -Wno-duplicate-decl-specifier
 
 MQTT_C_SOURCES = src/mqtt.c src/mqtt_pal.c
-MQTT_C_EXAMPLES = bin/simple_publisher bin/simple_subscriber bin/reconnect_subscriber bin/bio_publisher bin/openssl_publisher
+MQTT_C_EXAMPLES = bin/simple_publisher bin/simple_subscriber bin/reconnect_subscriber bin/bio_publisher bin/openssl_publisher bin/pal_client_ref 
 MQTT_C_UNITTESTS = bin/tests
 BINDIR = bin
 
@@ -20,6 +20,9 @@ bin/bio_%: examples/bio_%.c $(MQTT_C_SOURCES)
 
 bin/openssl_%: examples/openssl_%.c $(MQTT_C_SOURCES)
 	$(CC) $(CFLAGS) -D MQTT_USE_BIO $^ -lpthread `pkg-config --libs openssl` -o $@
+
+bin/pal_%: examples/pal_%.c src/mqtt.c
+	$(CC) $(CFLAGS) -D MQTT_USE_CUSTOM_PAL_PTR $^ -lpthread -o $@
 
 $(BINDIR):
 	mkdir -p $(BINDIR)

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -484,7 +484,11 @@ ssize_t __mqtt_send(struct mqtt_client *client)
         }
 
         /* we're sending the message */
+#ifdef MQTT_USE_CUSTOM_PAL_PTR
+        ssize_t tmp = mqtt_pal_sendall(client->socketfd, msg->start, msg->size, 0, client);
+#else
         ssize_t tmp = mqtt_pal_sendall(client->socketfd, msg->start, msg->size, 0);
+#endif
         if (tmp < 0) {
             client->error = tmp;
             MQTT_PAL_MUTEX_UNLOCK(&client->mutex);
@@ -571,7 +575,11 @@ ssize_t __mqtt_recv(struct mqtt_client *client)
         /* read in as many bytes as possible */
         ssize_t rv, consumed;
 
+#ifdef MQTT_USE_CUSTOM_PAL_PTR
+        rv = mqtt_pal_recvall(client->socketfd, client->recv_buffer.curr, client->recv_buffer.curr_sz, 0, client);
+#else
         rv = mqtt_pal_recvall(client->socketfd, client->recv_buffer.curr, client->recv_buffer.curr_sz, 0);
+#endif
         if (rv < 0) {
             /* an error occurred */
             client->error = rv;


### PR DESCRIPTION
Hey I made this two optional additions:
* A custom pointer to store additional info and states for each client. `mqtt_client->custom`
* Option to pass the client pointer to the PAL. In combination with the custom pointer this can be used to forward the send and recv calls to an existing network implementation.
Can be turned on with `MQTT_USE_CUSTOM_PAL_PTR`

Thank you for the great library!