### PR TITLE
Fixed DUP Flag in PUBLISH packets when using QoS 1

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -555,7 +555,7 @@ ssize_t __mqtt_send(struct mqtt_client *client)
             msg->state = MQTT_QUEUED_COMPLETE;
             break;
         case MQTT_CONTROL_PUBLISH:
-            inspected = MQTT_PUBLISH_QOS_MASK & ((msg->start[0]) >> 1); /* qos */
+            inspected = ( MQTT_PUBLISH_QOS_MASK & (msg->start[0]) ) >> 1; /* qos */
             if (inspected == 0) {
                 msg->state = MQTT_QUEUED_COMPLETE;
             } else if (inspected == 1) {

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -560,7 +560,7 @@ ssize_t __mqtt_send(struct mqtt_client *client)
                 msg->state = MQTT_QUEUED_COMPLETE;
             } else if (inspected == 1) {
                 msg->state = MQTT_QUEUED_AWAITING_ACK;
-                /*set DUP flag for subsequent sends */ 
+                /*set DUP flag for subsequent sends [Spec MQTT-3.3.1-1] */ 
                 msg->start[0] |= MQTT_PUBLISH_DUP;
             } else {
                 msg->state = MQTT_QUEUED_AWAITING_ACK;
@@ -1244,12 +1244,12 @@ ssize_t mqtt_pack_publish_request(uint8_t *buf, size_t bufsz,
     remaining_length += application_message_size;
     fixed_header.remaining_length = remaining_length;
 
-    /* force dup to 0 if qos is 0 */
+    /* force dup to 0 if qos is 0 [Spec MQTT-3.3.1-2] */
     if (inspected_qos == 0) {
         publish_flags &= ~MQTT_PUBLISH_DUP;
     }
 
-    /* make sure that qos is not 3 */
+    /* make sure that qos is not 3 [Spec MQTT-3.3.1-4] */
     if (inspected_qos == 3) {
         return MQTT_ERROR_PUBLISH_FORBIDDEN_QOS;
     }

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -561,7 +561,7 @@ ssize_t __mqtt_send(struct mqtt_client *client)
             } else if (inspected == 1) {
                 msg->state = MQTT_QUEUED_AWAITING_ACK;
                 /*set DUP flag for subsequent sends */ 
-                msg->start[1] |= MQTT_PUBLISH_DUP;
+                msg->start[0] |= MQTT_PUBLISH_DUP;
             } else {
                 msg->state = MQTT_QUEUED_AWAITING_ACK;
             }

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -555,7 +555,7 @@ ssize_t __mqtt_send(struct mqtt_client *client)
             msg->state = MQTT_QUEUED_COMPLETE;
             break;
         case MQTT_CONTROL_PUBLISH:
-            inspected = 0x06 & ((msg->start[0]) >> 1); /* qos */
+            inspected = MQTT_PUBLISH_QOS_MASK & ((msg->start[0]) >> 1); /* qos */
             if (inspected == 0) {
                 msg->state = MQTT_QUEUED_COMPLETE;
             } else if (inspected == 1) {
@@ -1231,7 +1231,7 @@ ssize_t mqtt_pack_publish_request(uint8_t *buf, size_t bufsz,
     }
 
     /* inspect QoS level */
-    inspected_qos = (publish_flags & 0x06) >> 1; /* mask */
+    inspected_qos = (publish_flags & MQTT_PUBLISH_QOS_MASK) >> 1; /* mask */
 
     /* build the fixed header */
     fixed_header.control_type = MQTT_CONTROL_PUBLISH;
@@ -1293,7 +1293,7 @@ ssize_t mqtt_unpack_publish_response(struct mqtt_response *mqtt_response, const 
 
     /* get flags */
     response->dup_flag = (fixed_header->control_flags & MQTT_PUBLISH_DUP) >> 3;
-    response->qos_level = (fixed_header->control_flags & 0x06) >> 1;
+    response->qos_level = (fixed_header->control_flags & MQTT_PUBLISH_QOS_MASK) >> 1;
     response->retain_flag = fixed_header->control_flags & MQTT_PUBLISH_RETAIN;
 
     /* make sure that remaining length is valid */

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -555,7 +555,7 @@ ssize_t __mqtt_send(struct mqtt_client *client)
             msg->state = MQTT_QUEUED_COMPLETE;
             break;
         case MQTT_CONTROL_PUBLISH:
-            inspected = 0x03 & ((msg->start[0]) >> 1); /* qos */
+            inspected = 0x06 & ((msg->start[0]) >> 1); /* qos */
             if (inspected == 0) {
                 msg->state = MQTT_QUEUED_COMPLETE;
             } else if (inspected == 1) {


### PR DESCRIPTION
- Fixed mislocation of DUP flag in re-delivered PUBLISH packets.
- Fixed mask used to inspect QoS field (near the previous item) and, later on, used a mask defined in the header file instead of hardcoded values.
- Added some references to the MQTT specification as @halflete have done.