### PR TITLE
Simple send offset

### DIFF
--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -915,6 +915,7 @@ struct mqtt_queued_message {
     /** @brief The number of bytes in the message. */
     size_t size;
 
+
     /** @brief The state of the message. */
     enum MQTTQueuedMessageState state;
 
@@ -1086,6 +1087,13 @@ struct mqtt_client {
      * @see keep_alive
      */
     int number_of_keep_alives;
+
+    /**
+     * @brief The current sent offset.
+     *
+     * This is used to allow partial send commands.
+     */
+    size_t send_offset;
 
     /** 
      * @brief The timestamp of the last message sent to the buffer.


### PR DESCRIPTION
Hi

I discovered an issue in __mqtt_send. If the socket does not accept all the data, for example if it returns EAGAIN, the situation is not correctly handled and the message is assumed to be sent. 
This will for example result in the CONNECT message being discarded and a following publish to a broker may result in the broker terminating the connection.

The proposed fix is relatively simple, and covers all tests I have been able to make so far.