### PR TITLE
Fixed Wall compiler warnings

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -922,7 +922,7 @@ struct {
     }
 };
 
-ssize_t mqtt_fixed_header_rule_violation(const struct mqtt_fixed_header *fixed_header) {
+static ssize_t mqtt_fixed_header_rule_violation(const struct mqtt_fixed_header *fixed_header) {
     uint8_t control_type;
     uint8_t control_flags;
     uint8_t required_flags;

--- a/src/mqtt_pal.c
+++ b/src/mqtt_pal.c
@@ -87,7 +87,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
 }
 
 ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
-    const void const *start = buf;
+    const void *start = buf;
     ssize_t rv;
     do {
         rv = recv(fd, buf, bufsz, flags);

--- a/src/mqtt_pal.c
+++ b/src/mqtt_pal.c
@@ -87,7 +87,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
 }
 
 ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
-    const void *start = buf;
+    const void *const start = buf;
     ssize_t rv;
     do {
         rv = recv(fd, buf, bufsz, flags);


### PR DESCRIPTION
While compiling MQTT-C in an application on OpenWRT linux the compiler stopped me with two warnings in the source code. The first warning was that the function `mqtt_fixed_header_rule_violation` in `mqtt.c` was not declared. As this function is only used as a helper in the parser below I declared this function static.

In the file `mqtt_pal.c` a pointer was declared const twice which also rised a compiler warning.

As I'm compiling with `Wall` this prevented me from compiling MQTT-C, this pull request fixes the problem.