### PR TITLE
Add initial CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.2)
+project(MQTT-C)
+
+# Add this include directory for all applications
+include_directories(include)
+
+# Common source files
+set(MQTT_C_SOURCES src/mqtt.c src/mqtt_pal.c)
+
+
+# Search for threading library
+find_package(Threads REQUIRED)
+
+# Search for openssl
+find_package(OpenSSL REQUIRED)
+
+# Search the cmocka  unittest library
+find_library(CMOCKA_LIBRARY cmocka)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra -Wall -std=gnu99 -Iinclude -Wno-unused-parameter -Wno-unused-variable -Wno-duplicate-decl-specifier")
+
+# Simple projects
+add_executable(simple_publisher examples/simple_publisher.c ${MQTT_C_SOURCES})
+target_link_libraries(simple_publisher Threads::Threads)
+
+add_executable(simple_subscriber examples/simple_subscriber.c ${MQTT_C_SOURCES})
+target_link_libraries(simple_subscriber Threads::Threads)
+
+add_executable(reconnect_subscriber examples/reconnect_subscriber.c ${MQTT_C_SOURCES})
+target_link_libraries(reconnect_subscriber Threads::Threads)
+
+# Use BIO sockets
+add_executable(bio_publisher examples/bio_publisher.c ${MQTT_C_SOURCES})
+target_link_libraries(bio_publisher Threads::Threads OpenSSL::SSL)
+target_compile_definitions(bio_publisher PUBLIC MQTT_USE_BIO)
+
+# Encrypt connection using OpenSSL
+add_executable(openssl_publisher examples/openssl_publisher.c ${MQTT_C_SOURCES})
+target_link_libraries(openssl_publisher Threads::Threads OpenSSL::SSL)
+target_compile_definitions(openssl_publisher PUBLIC MQTT_USE_BIO)
+
+
+# Unit-tests
+add_executable(tests tests.c ${MQTT_C_SOURCES})
+target_include_directories(tests PUBLIC ${CMOCKA_INCLUDE_DIR})
+target_link_libraries(tests ${CMOCKA_LIBRARY})
+

--- a/README.md
+++ b/README.md
@@ -68,15 +68,18 @@ and the other modules contain documentation for MQTT-C developers.
 ## Testing and Building the Tests
 The MQTT-C unit tests use the [cmocka unit testing framework](https://cmocka.org/). 
 Therefore, [cmocka](https://cmocka.org/) *must* be installed on your machine to build and run 
-the unit tests. For convenience, a simple `"makefile"` is included to build the unit tests and 
-examples on UNIX-like machines. The unit tests and examples can be built as follows:
+the unit tests. Additionally, OpenSSL is required for the examples `bio_publisher` and `openssl_publisher`.
+For convenience, a simple `CMakeLists.txt` is included to create project files for the unit tests and examples using cmake. The unit tests and examples can be built as follows (On UNIX-like machines):
 ```bash
+    $ mkdir bin
+    $ cd bin
+    $ cmake ..
     $ make all
 ``` 
 The unit tests and examples will be built in the `"bin/"` directory. The unit tests can be run 
 like so:
 ```bash
-    $ ./bin/tests [address [port]]
+    $ ./tests [address [port]]
 ```
 Note that the \c address and \c port arguments are both optional to specify the location of the
 MQTT broker that is to be used for the tests. If no \c address is given then the 


### PR DESCRIPTION
Please note:

- I have only tested this on `wsl`
- There is no multi-platform support yet, all I did for now was mimic the original makefile
- I left the makefile intact (for now), in case it does not work for someone yet.