### PR TITLE
Added if condition to avoid null pointer arithmetic 

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -1568,12 +1568,15 @@ ssize_t mqtt_pack_unsubscribe_request(uint8_t *buf, size_t bufsz, unsigned int p
 
 /* MESSAGE QUEUE */
 void mqtt_mq_init(struct mqtt_message_queue *mq, void *buf, size_t bufsz) 
-{
-    mq->mem_start = buf;
-    mq->mem_end = (unsigned char*)buf + bufsz;
-    mq->curr = buf;
-    mq->queue_tail = mq->mem_end;
-    mq->curr_sz = mqtt_mq_currsz(mq);
+{  
+    if(buf != NULL)
+    {
+        mq->mem_start = buf;
+        mq->mem_end = (unsigned char*)buf + bufsz;
+        mq->curr = buf;
+        mq->queue_tail = mq->mem_end;
+        mq->curr_sz = mqtt_mq_currsz(mq);
+    }
 }
 
 struct mqtt_queued_message* mqtt_mq_register(struct mqtt_message_queue *mq, size_t nbytes)


### PR DESCRIPTION
This error was shown to me by cppcheck, that it could be possible that buf is NULL. Performing arithmetic with NULL pointers may result in undefined behavior, so I caught this by checking if buf is NULL. 

Compilation and test ran successfully after this change.