### PR TITLE
Fix wrong remaining length size

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -1244,7 +1244,7 @@ ssize_t mqtt_pack_publish_request(uint8_t *buf, size_t bufsz,
     const uint8_t *const start = buf;
     ssize_t rv;
     struct mqtt_fixed_header fixed_header;
-    uint16_t remaining_length;
+    uint32_t remaining_length;
     uint8_t inspected_qos;
 
     /* check for null pointers */


### PR DESCRIPTION
The remaining length in the `mqtt_pack_publish_request` function was too small, I have changed this to a 32 bit unsigned integer. The library now allows the client to publish packets of the maximum allowed length according to the spec.