### PR TITLE
Correct header installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,5 @@ endif()
 install(TARGETS mqttc 
     DESTINATION lib
 )
-install(DIRECTORY include
-    DESTINATION include
-)
+install(DIRECTORY include/
+    DESTINATION include)


### PR DESCRIPTION
Install as:

    /usr/local/include/mqtt.h

instead of:

    /usr/local/include/include/mqtt.h