### PR TITLE
Issue/91 Unaligned TX buffer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
     <a href="https://github.com/LiamBindle/MQTT-C/blob/master/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg"></a>
 </p>
 
-# 
-
 MQTT-C is an [MQTT v3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) 
 client written in C. MQTT is a lightweight publisher-subscriber-based messaging protocol that is
 commonly used in IoT and networking applications where high-latency and low data-rate links 

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -1308,6 +1308,22 @@ enum MQTTErrors mqtt_sync(struct mqtt_client *client);
  * 
  * @attention Only initialize an MQTT client once (i.e. don't call \ref mqtt_init or 
  *            \ref mqtt_init_reconnect more than once per client).
+ * @attention \p sendbuf internally mapped to client's message-to-send queue that actively uses
+ *            pointer access. In the case of unaligned \p sendbuf, that may lead to
+ *            Segmentation/Hard/Memory Faults on systems that do not support unaligned pointer
+ *            access (e.g. ARMv6, ARMv7-M). To avoid that, you may use the following technique:
+ *            \code{.c}
+ *            // example for ARMv7-M that requires pointers to be word aligned (4 byte boundary)
+ *            static unsigned char mqtt_tx_buffer[MAX_TX_BUFFER_SIZE] __attribute__((aligned(4)));
+ *            static unsigned char mqtt_rx_buffer[MAX_RX_BUFFER_SIZE];
+ *            // ...
+ *            int main(void) {
+ *                // ...
+ *                mqtt_init(p_client, p_client->socketfd, mqtt_tx_buffer, sizeof mqtt_tx_buffer, mqtt_rx_buffer,
+ *                          sizeof mqtt_rx_buffer, message_callback);
+ *                // ...
+ *            }
+ *            \endcode
  * 
  * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */


### PR DESCRIPTION
Add:
 - attention block with unaligned `sendbuf` issue description (#91)

Update:
 - `README.md` to avoid `autotoc_md0` generation due to empty `#` statement
 - `docs/` output