### PR TITLE
Add mqtt_reconnect

### DIFF
--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -177,7 +177,7 @@ struct mqtt_fixed_header {
     MQTT_ERROR(MQTT_ERROR_MALFORMED_RESPONSE)            \
     MQTT_ERROR(MQTT_ERROR_UNSUBSCRIBE_TOO_MANY_TOPICS)   \
     MQTT_ERROR(MQTT_ERROR_RESPONSE_INVALID_CONTROL_TYPE) \
-    MQTT_ERROR(MQTT_ERROR_CONNECT_NOT_CALLED)          \
+    MQTT_ERROR(MQTT_ERROR_CONNECT_NOT_CALLED)            \
     MQTT_ERROR(MQTT_ERROR_SEND_BUFFER_IS_FULL)           \
     MQTT_ERROR(MQTT_ERROR_SOCKET_ERROR)                  \
     MQTT_ERROR(MQTT_ERROR_MALFORMED_REQUEST)             \
@@ -189,7 +189,8 @@ struct mqtt_fixed_header {
     MQTT_ERROR(MQTT_ERROR_CONNECTION_CLOSED)             \
     MQTT_ERROR(MQTT_ERROR_INITIAL_RECONNECT)             \
     MQTT_ERROR(MQTT_ERROR_INVALID_REMAINING_LENGTH)      \
-    MQTT_ERROR(MQTT_ERROR_CLEAN_SESSION_IS_REQUIRED)
+    MQTT_ERROR(MQTT_ERROR_CLEAN_SESSION_IS_REQUIRED)     \
+    MQTT_ERROR(MQTT_ERROR_RECONNECTING)
 
 /* todo: add more connection refused errors */
 
@@ -1565,4 +1566,22 @@ enum MQTTErrors __mqtt_ping(struct mqtt_client *client);
  */
 enum MQTTErrors mqtt_disconnect(struct mqtt_client *client);
 
+/**
+ * @brief Terminate the session with the MQTT broker and prepare to
+ * reconnect. Client code should call \ref mqtt_sync immediately 
+ * after this call to prevent message loss.
+ * @ingroup api
+ * 
+ * @note The user must provide a reconnect callback function for this to 
+ * work as expected. See \r mqtt_client_reconnect.
+ * 
+ * @pre mqtt_connect must have been called
+* 
+ * @param[in,out] client The MQTT client.
+ * 
+ * @note To re-establish the session, mqtt_connect must be called.
+ * 
+ * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
+ */
+enum MQTTErrors mqtt_reconnect(struct mqtt_client *client);
 #endif

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -1579,8 +1579,6 @@ enum MQTTErrors mqtt_disconnect(struct mqtt_client *client);
 * 
  * @param[in,out] client The MQTT client.
  * 
- * @note To re-establish the session, mqtt_connect must be called.
- * 
  * @returns \c MQTT_OK upon success, an \ref MQTTErrors otherwise.
  */
 enum MQTTErrors mqtt_reconnect(struct mqtt_client *client);


### PR DESCRIPTION
Due to the nature of my particular requirements I added an additional function to cause a forced reconnect. 

### A Little Background
When one connect to an Azure IoT hub there are a couple of ways a device can authenticate. It can use X.509 client certificates or it can use a SAS Token. In the case of the latter, a SAS Token has a fixed time to live in that, if you generate it with an hour of life then, once that hour expires, the SAS Token will no longer be valid for authentication thus one needs to disconnect, generate a new SAS Token (which is passed as the MQTT password) and reconnect.
### The Problem
I have my application set up so that my reconnect callback function is called by the MQTT-C library when something goes awry. This works fine for transient network issues but does not work well when one wants to explicitly disconnect. My code essentially looks like this:
```
while (keep_running) {
   If (my_sas_token < 20% life left) {
      mqtt_disconnect()
   }
   if (two seconds has elapsed since I sent data) {
      mqtt_publish()
   }
   mqtt_sync()
   sleep 100 milliseconds
}
```
In this scenario the mqtt_disconnect should, according to the spec, cause the server to close the socket which it does. However, about four seconds goes by before my socket write fails. This causes two additional messages to be published after the disconnect packet has been sent. These will obviously be tossed. This is not ideal for my application. 
### My Suggested Solution
I looked at dealing with this issue inside my application such as suspending the publishing until the connection had been reset but this didn't work. When the library has nothing to publish it will not write to the socket and it appears that, at least for a few minutes anyway, it can merrily read that socket even though the other end has been closed. This means, in order to force my reconnection callback to be invoked I would need to publish a garbage message after the disconnect call to force a socket write that would fail. I was not enamored with that design.

So addressed this issue in your code instead. I added an additional MQTT_ERROR called MQTT_ERROR_RECONNECTING. This is set in the mqtt_reconnect function. Other than calling mqtt_disconnect that is pretty much all it does.

In mqtt_sync I check for that status and, if it is set, I set a flag and replace it with MQTT_OK. This allows __mqtt_send and _mqtt_recv to run as normal which will cause the disconnect packet to be sent to the server. After this has happened I check the flag to see if it is reconnecting status and, if so, call the reconnect callback function which will close the socket and reconnect.

It's actually a fairly small change and will not break any existing clients.

Let me know what you think.

Thanks.

M