### PR TITLE
mqttc: Add an option to specify own MQTT-C PAL header file

### DIFF
--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -29,6 +29,12 @@ SOFTWARE.
 extern "C" {
 #endif
 
+// Users can override mqtt_pal.h with their own configuration by defining
+// MQTTC_PAL_FILE as a header file to include (-DMQTTC_PAL_FILE=my_mqtt_pal.h).
+//
+// If MQTTC_PAL_FILE is used, none of the default utils will be emitted and must be
+// provided by the config file. To start, I would suggest copying mqtt_pal.h
+// and modifying as needed.
 #ifdef MQTTC_PAL_FILE
 #define MQTTC_STR2(x) #x
 #define MQTTC_STR(x) MQTTC_STR2(x)

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -29,7 +29,13 @@ SOFTWARE.
 extern "C" {
 #endif
 
+#ifdef MQTTC_PAL_FILE
+#define MQTTC_STR2(x) #x
+#define MQTTC_STR(x) MQTTC_STR2(x)
+#include MQTTC_STR(MQTTC_PAL_FILE)
+#else
 #include <mqtt_pal.h>
+#endif /* MQTT_PAL_FILE */
 
 /**
  * @file


### PR DESCRIPTION
Add an option to specify own MQTT-C PAL header file

As we discussed in the #89 it will be great for an user to be able to specify theirs own MQTT PAL header file. That way they will be able to overwrite required PAL interface for a end platform without dealing with existing `mqtt_pal.h` file that sits right next to the `mqtt.h`