### PR TITLE
When a stream socket peer has performed an orderly shutdown, the retu…

### DIFF
--- a/src/mqtt_pal.c
+++ b/src/mqtt_pal.c
@@ -332,7 +332,7 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
             /* successfully read bytes from the socket */
             buf += rv;
             bufsz -= rv;
-        } else if (rv < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+        } else if (rv == 0 || (rv < 0 && errno != EAGAIN && errno != EWOULDBLOCK)) {
             /* an error occurred that wasn't "nothing to read". */
             return MQTT_ERROR_SOCKET_ERROR;
         }


### PR DESCRIPTION
…rn value will be 0 (the traditional end-of-file return).

https://man7.org/linux/man-pages/man2/recvmsg.2.html