### PR TITLE
Switch from fcntl to ioctl on OpenVMS for posix_sockets.h

### DIFF
--- a/examples/templates/posix_sockets.h
+++ b/examples/templates/posix_sockets.h
@@ -7,6 +7,9 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #endif
+#if defined(__VMS)
+#include <ioctl.h>
+#endif
 #include <fcntl.h>
 
 /*
@@ -54,6 +57,15 @@ int open_nb_socket(const char* addr, const char* port) {
         int iMode = 1;
         ioctlsocket(sockfd, FIONBIO, &iMode);
     }
+#endif
+#if defined(__VMS)
+    /* 
+        OpenVMS only partially implements fcntl. It works on file descriptors
+        but silently fails on socket descriptors. So we need to fall back on
+        to the older ioctl system to set non-blocking IO
+    */
+    int on = 1;                 
+    if (sockfd != -1) ioctl(sockfd, FIONBIO, &on);
 #endif
 
     /* return the new socket fd */


### PR DESCRIPTION
The implementation of fcntl is not entirely POSIX compliant on OpenVMS. It works as per the specs for file descriptors, but some parts of the socket descriptors interface are not implemented. In the case of the MQTT library it means that non-blocking IO cannot be set this way. Even worse it fails silently without warnings at compile or runtime. 

The solution is simply to switch to using the older ioctl system for setting non-blocking IO. 

The pull request here relies on the `__VMS` define set by the compiler on OpenVMS. The existing call to fcntl (~line 54) still happens but does nothing. I've not changed the preceding `#ifndef` so as to minimise changes to the logic, but the define checks could be rewritten so that it's not called at all.