### PR TITLE
Set MQTT_PAL_MUTEX_INIT to use a recursive mutex

### DIFF
--- a/include/mqtt_pal.h
+++ b/include/mqtt_pal.h
@@ -85,7 +85,13 @@ extern "C" {
     typedef time_t mqtt_pal_time_t;
     typedef pthread_mutex_t mqtt_pal_mutex_t;
 
-    #define MQTT_PAL_MUTEX_INIT(mtx_ptr) pthread_mutex_init(mtx_ptr, NULL)
+    #define MQTT_PAL_MUTEX_INIT(mtx_ptr) { \
+        pthread_mutexattr_t attr; \
+        pthread_mutexattr_init(&attr); \
+        pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE); \
+        pthread_mutex_init(mtx_ptr, &attr); \
+    }
+    //#define MQTT_PAL_MUTEX_INIT(mtx_ptr) pthread_mutex_init(mtx_ptr, NULL)
     #define MQTT_PAL_MUTEX_LOCK(mtx_ptr) pthread_mutex_lock(mtx_ptr)
     #define MQTT_PAL_MUTEX_UNLOCK(mtx_ptr) pthread_mutex_unlock(mtx_ptr)
 


### PR DESCRIPTION
This is pretty clearly an alternate take on @basilaljamal 's pull request #123, and an attempt at a solution to issue #88.

I've moved all the code changes into mqtt_pal.h and made it platform-specific to POSIX platforms, by redefining MQTT_PAL_MUTEX_INIT. But I'm not sure if this is the right approach. Should MQTT_PAL_MUTEX_INIT be converted into a function instead of a multiline define? Should a define switch be used to control whether recursive mutexes are used?

```
#ifndef MQTT_USE_MUTEX_RECURSIVE
#define MQTT_PAL_MUTEX_INIT(mtx_ptr) pthread_mutex_init(mtx_ptr, NULL)
#else
#define MQTT_PAL_MUTEX_INIT(mtx_ptr) { ... }
#endif
```

Happy for feedback!