### PR TITLE
Revert "Fixed bug in UNIX PAL that caused MQTT_ERROR_SOCKET_ERROR whe…

### DIFF
--- a/src/mqtt_pal.c
+++ b/src/mqtt_pal.c
@@ -332,7 +332,7 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
             /* successfully read bytes from the socket */
             buf += rv;
             bufsz -= rv;
-        } else if (rv <= 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+        } else if (rv == 0 || (rv < 0 && errno != EAGAIN && errno != EWOULDBLOCK)) {
             /* an error occurred that wasn't "nothing to read". */
             return MQTT_ERROR_SOCKET_ERROR;
         }


### PR DESCRIPTION
…n mqtt_pal_recvall() returned 0 bytes but EAGAIN or EWOULDBLOCK was set"

This reverts commit 32b7f2cdef0858fd4b137b451f88c6735583efb8.

Because it seems wrong.

errno is supposed to be set only when recv() returns -1.
if it was a workaround for a particular OS bug or something like that,
it should be conditionalized and commented boldly.