### PR TITLE
Removed * 0.75 to be compliant with documentation

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -622,7 +622,7 @@ ssize_t __mqtt_send(struct mqtt_client *client)
 
     /* check for keep-alive */
     {
-        mqtt_pal_time_t keep_alive_timeout = client->time_of_last_send + (mqtt_pal_time_t)((float)(client->keep_alive) * 0.75);
+        mqtt_pal_time_t keep_alive_timeout = client->time_of_last_send + (mqtt_pal_time_t)((float)(client->keep_alive));
         if (MQTT_PAL_TIME() > keep_alive_timeout) {
           ssize_t rv = __mqtt_ping(client);
           if (rv != MQTT_OK) {


### PR DESCRIPTION
According to oasis-open MQTT documentation:
_If the Keep Alive value is non-zero and the Server does not receive a Control Packet from the Client within one and a half times the Keep Alive time period, it MUST disconnect the Network Connection to the Client as if the network had failed_
Link to documentation:
http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349238


That means the client have up to Keep Alive * 1.5 to send a the keep alive, which should be plenty.

Therefor the client library should not change the interval to less than what the user set.