### PR TITLE
Fixed some conversion errors that occur when the -Wc++-compat compiler flag is enabled

### DIFF
--- a/examples/templates/mbedtls_sockets.h
+++ b/examples/templates/mbedtls_sockets.h
@@ -35,6 +35,14 @@ struct mbedtls_context {
     mbedtls_ctr_drbg_context ctr_drbg;
 };
 
+void failed(const char *fn, int rv);
+void cert_verify_failed(uint32_t rv);
+void open_nb_socket(struct mbedtls_context *ctx,
+                    const char *hostname,
+                    const char *port,
+                    const char *ca_file);
+
+
 void failed(const char *fn, int rv) {
     char buf[100];
     mbedtls_strerror(rv, buf, sizeof(buf));
@@ -52,11 +60,6 @@ void cert_verify_failed(uint32_t rv) {
 /*
     A template for opening a non-blocking mbed TLS connection.
 */
-void open_nb_socket(struct mbedtls_context *ctx,
-                    const char *hostname,
-                    const char *port,
-                    const char *ca_file);
-
 void open_nb_socket(struct mbedtls_context *ctx,
                     const char *hostname,
                     const char *port,
@@ -129,7 +132,7 @@ void open_nb_socket(struct mbedtls_context *ctx,
         } else {
             break;
         }
-        rv = mbedtls_net_poll(net_ctx, want, -1);
+        rv = mbedtls_net_poll(net_ctx, want, (uint32_t)-1);
         if (rv < 0) {
             failed("mbedtls_net_poll", rv);
         }
@@ -140,7 +143,7 @@ void open_nb_socket(struct mbedtls_context *ctx,
     uint32_t result = mbedtls_ssl_get_verify_result(ssl_ctx);
     if (result != 0) {
         if (result == (uint32_t)-1) {
-            failed("mbedtls_ssl_get_verify_result", result);
+            failed("mbedtls_ssl_get_verify_result", (int)result);
         } else {
             cert_verify_failed(result);
         }

--- a/examples/templates/mbedtls_sockets.h
+++ b/examples/templates/mbedtls_sockets.h
@@ -55,6 +55,11 @@ void cert_verify_failed(uint32_t rv) {
 void open_nb_socket(struct mbedtls_context *ctx,
                     const char *hostname,
                     const char *port,
+                    const char *ca_file);
+
+void open_nb_socket(struct mbedtls_context *ctx,
+                    const char *hostname,
+                    const char *port,
                     const char *ca_file) {
     const unsigned char *additional = (const unsigned char *)"MQTT-C";
     size_t additional_len = 6;

--- a/examples/templates/openssl_sockets.h
+++ b/examples/templates/openssl_sockets.h
@@ -5,9 +5,20 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
+#include <string.h>
+
 /*
     A template for opening a non-blocking OpenSSL connection.
 */
+void open_nb_socket(BIO**       bio,
+                    SSL_CTX**   ssl_ctx,
+                    const char* addr,
+                    const char* port,
+                    const char* ca_file,
+                    const char* ca_path,
+                    const char* cert_file,
+                    const char* key_file);
+
 void open_nb_socket(BIO**       bio,
                     SSL_CTX**   ssl_ctx,
                     const char* addr,
@@ -42,18 +53,26 @@ void open_nb_socket(BIO**       bio,
     }
 
     /* open BIO socket */
+    char * addr_copy = (char*)malloc(strlen(addr) + 1);
+    strcpy(addr_copy,addr);
+    char * port_copy = (char*)malloc(strlen(port) + 1);
+    strcpy(port_copy,port);
+
     *bio = BIO_new_ssl_connect(*ssl_ctx);
     BIO_get_ssl(*bio, &ssl);
     SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
-    BIO_set_conn_hostname(*bio, addr);
+    BIO_set_conn_hostname(*bio, addr_copy);
     BIO_set_nbio(*bio, 1);
-    BIO_set_conn_port(*bio, port);
+    BIO_set_conn_port(*bio, port_copy);
+
+    free(addr_copy);
+    free(port_copy);
 
     /* wait for connect with 10 second timeout */
-    int start_time = time(NULL);
-    int do_connect_rv = BIO_do_connect(*bio);
+    int start_time = (int)time(NULL);
+    int do_connect_rv = (int)BIO_do_connect(*bio);
     while(do_connect_rv <= 0 && BIO_should_retry(*bio) && (int)time(NULL) - start_time < 10) {
-        do_connect_rv = BIO_do_connect(*bio);
+        do_connect_rv = (int)BIO_do_connect(*bio);
     }
     if (do_connect_rv <= 0) {
         printf("error: %s\n", ERR_reason_error_string(ERR_get_error()));

--- a/examples/templates/posix_sockets.h
+++ b/examples/templates/posix_sockets.h
@@ -17,6 +17,8 @@
 /*
     A template for opening a non-blocking POSIX socket.
 */
+int open_nb_socket(const char* addr, const char* port);
+
 int open_nb_socket(const char* addr, const char* port) {
     struct addrinfo hints = {0};
 

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -283,7 +283,7 @@ uint16_t __mqtt_unpack_uint16(const uint8_t *buf);
 ssize_t __mqtt_pack_str(uint8_t *buf, const char* str);
 
 /** @brief A macro to get the MQTT string length from a c-string. */
-#define __mqtt_packed_cstrlen(x) (2 + strlen(x))
+#define __mqtt_packed_cstrlen(x) (2 + (unsigned int)strlen(x))
 
 /* RESPONSES */
 

--- a/src/mqtt_pal.c
+++ b/src/mqtt_pal.c
@@ -299,7 +299,7 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
 ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
     size_t sent = 0;
     while(sent < len) {
-        int tmp = BIO_write(fd, (const char*)buf + sent, len - sent);
+        int tmp = BIO_write(fd, (const char*)buf + sent, (int)(len - sent));
         if (tmp > 0) {
             sent += (size_t) tmp;
         } else if (tmp <= 0 && !BIO_should_retry(fd)) {
@@ -307,19 +307,19 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
         }
     }
     
-    return sent;
+    return (ssize_t)sent;
 }
 
 ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
-    const char* const start = buf;
-    char* bufptr = buf;
+    const char* const start = (const char*)buf;
+    char* bufptr = (char*)buf;
     int rv;
     do {
-        rv = BIO_read(fd, bufptr, bufsz);
+        rv = BIO_read(fd, bufptr, (int)bufsz);
         if (rv > 0) {
             /* successfully read bytes from the socket */
             bufptr += rv;
-            bufsz -= rv;
+            bufsz -= (unsigned long)rv;
         } else if (!BIO_should_retry(fd)) {
             /* an error occurred that wasn't "nothing to read". */
             return MQTT_ERROR_SOCKET_ERROR;
@@ -337,7 +337,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     enum MQTTErrors error = 0;
     size_t sent = 0;
     while(sent < len) {
-        ssize_t rv = send(fd, buf + sent, len - sent, flags);
+        ssize_t rv = send(fd, (const char*)buf + sent, len - sent, flags);
         if (rv < 0) {
             if (errno == EAGAIN) {
                 /* should call send later again */
@@ -356,7 +356,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     if (sent == 0) {
         return error;
     }
-    return sent;
+    return (ssize_t)sent;
 }
 
 ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
@@ -384,12 +384,12 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
             break;
         }
         buf = (char*)buf + rv;
-        bufsz -= rv;
+        bufsz -= (unsigned long)rv;
     } while (bufsz > 0);
     if (buf == start) {
         return error;
     }
-    return buf - start;
+    return (char*)buf - (const char*)start;
 }
 
 #elif defined(_MSC_VER) || defined(WIN32)

--- a/src/mqtt_pal.c
+++ b/src/mqtt_pal.c
@@ -51,7 +51,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     enum MQTTErrors error = 0;
     size_t sent = 0;
     while(sent < len) {
-        int rv = mbedtls_ssl_write(fd, buf + sent, len - sent);
+        int rv = mbedtls_ssl_write(fd, (const unsigned char*)buf + sent, len - sent);
         if (rv < 0) {
             if (rv == MBEDTLS_ERR_SSL_WANT_READ ||
                 rv == MBEDTLS_ERR_SSL_WANT_WRITE
@@ -79,7 +79,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     if (sent == 0) {
         return error;
     }
-    return sent;
+    return (ssize_t)sent;
 }
 
 ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
@@ -87,7 +87,7 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
     enum MQTTErrors error = 0;
     int rv;
     do {
-        rv = mbedtls_ssl_read(fd, buf, bufsz);
+        rv = mbedtls_ssl_read(fd, (unsigned char*)buf, bufsz);
         if (rv == 0) {
             /*
              * Note: mbedtls_ssl_read returns 0 when the underlying
@@ -116,12 +116,12 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
             break;
         }
         buf = (char*)buf + rv;
-        bufsz -= rv;
+        bufsz -= (unsigned long)rv;
     } while (bufsz > 0);
     if (buf == start) {
         return error;
     }
-    return buf - start;
+    return (const char *)buf - (const char*)start;
 }
 
 #elif defined(MQTT_USE_WOLFSSL)


### PR DESCRIPTION
The compiler flag -Wc++-compat causes some errors in the build process. These are conversion errors that I fixed in this PR.
Attached is a [build.log](https://github.com/LiamBindle/MQTT-C/files/8464601/build.log).

We are using the MQTT library in the open-source project open62541. For this reason, it would be great if the PR is merged as soon as possible. Also, it would be great if a new tag could be created after the merge, which we can then use for our git submodules.
Thanks