### PR TITLE
Cross-compilation through Zig compiler toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 bin/
 build/
 .idea/
+zig-cache/
+zig-out/
+.DS_Store

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    // Standard release options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
+    const mode = b.standardReleaseOptions();
+
+    const lib = b.addStaticLibrary("MQTT-C", null);
+
+    lib.addIncludeDir("include");
+
+    lib.addCSourceFile("src/mqtt.c", &[_][]const u8 {});
+    lib.addCSourceFile("src/mqtt_pal.c", &[_][]const u8 {});
+
+    lib.linkLibC();
+
+    lib.setBuildMode(mode);
+    lib.install();
+}

--- a/build.zig
+++ b/build.zig
@@ -1,19 +1,52 @@
+// Used the following as cross-compilation build.zig example:
+// https://git.sr.ht/~jamii/focus/tree/master/build.zig
+
+const builtin = @import("builtin");
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
-    // Standard release options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
+pub fn build(b: *std.build.Builder) !void {
+    // var target = b.standardTargetOptions(.{});
 
-    const lib = b.addStaticLibrary("MQTT-C", null);
+    const windows = b.addStaticLibrary("mqtt-c", null);
+    try includeCommon(windows);
+    windows.setTarget(std.zig.CrossTarget{
+        .cpu_arch = .x86_64,
+        .os_tag = .windows,
+    });
+    windows.install();
 
+    const m1_mac = b.addStaticLibrary("mqtt-c-m1", null);
+    try includeCommon(m1_mac);
+    m1_mac.setTarget(std.zig.CrossTarget{
+        .cpu_arch = .aarch64,
+        .os_tag = .macos,
+    });
+    m1_mac.install();
+
+    const x64_mac = b.addStaticLibrary("mqtt-c-x64", null);
+    try includeCommon(x64_mac);
+    x64_mac.setTarget(std.zig.CrossTarget{
+        .cpu_arch = .x86_64,
+        .os_tag = .macos,
+    });
+    x64_mac.install();
+
+    const windows_step = b.step("windows", "Build for Windows");
+    windows_step.dependOn(&windows.step);
+
+    const m1_mac_step = b.step("m1_mac", "Build for M1 Mac");
+    m1_mac_step.dependOn(&m1_mac.step);
+
+    const x64_mac_step = b.step("x64_mac", "Build for M1 Mac");
+    x64_mac_step.dependOn(&x64_mac.step);
+}
+
+fn includeCommon(lib: *std.build.LibExeObjStep) !void {
     lib.addIncludeDir("include");
 
     lib.addCSourceFile("src/mqtt.c", &[_][]const u8 {});
     lib.addCSourceFile("src/mqtt_pal.c", &[_][]const u8 {});
 
+    lib.setBuildMode(.Debug); // Can be .Debug, .ReleaseSafe, .ReleaseFast, and .ReleaseSmall
     lib.linkLibC();
-
-    lib.setBuildMode(mode);
-    lib.install();
 }

--- a/build.zig
+++ b/build.zig
@@ -1,12 +1,9 @@
 // Used the following as cross-compilation build.zig example:
 // https://git.sr.ht/~jamii/focus/tree/master/build.zig
 
-const builtin = @import("builtin");
 const std = @import("std");
 
 pub fn build(b: *std.build.Builder) !void {
-    // var target = b.standardTargetOptions(.{});
-
     const windows = b.addStaticLibrary("mqtt-c", null);
     try includeCommon(windows);
     windows.setTarget(std.zig.CrossTarget{
@@ -15,30 +12,52 @@ pub fn build(b: *std.build.Builder) !void {
     });
     windows.install();
 
-    const m1_mac = b.addStaticLibrary("mqtt-c-m1", null);
-    try includeCommon(m1_mac);
-    m1_mac.setTarget(std.zig.CrossTarget{
+    const apple_silicon_mac = b.addStaticLibrary("mqtt-c-apple-silicon", null);
+    try includeCommon(apple_silicon_mac);
+    apple_silicon_mac.setTarget(std.zig.CrossTarget{
         .cpu_arch = .aarch64,
         .os_tag = .macos,
     });
-    m1_mac.install();
+    apple_silicon_mac.install();
 
-    const x64_mac = b.addStaticLibrary("mqtt-c-x64", null);
-    try includeCommon(x64_mac);
-    x64_mac.setTarget(std.zig.CrossTarget{
+    const x86_64_mac = b.addStaticLibrary("mqtt-c-mac-x64", null);
+    try includeCommon(x86_64_mac);
+    x86_64_mac.setTarget(std.zig.CrossTarget{
         .cpu_arch = .x86_64,
         .os_tag = .macos,
     });
-    x64_mac.install();
+    x86_64_mac.install();
+
+    const x86_64_linux = b.addStaticLibrary("mqtt-c-x64", null);
+    try includeCommon(x86_64_linux);
+    x86_64_linux.setTarget(std.zig.CrossTarget{
+        .cpu_arch = .x86_64,
+        .os_tag = .linux,
+    });
+    x86_64_linux.install();
+
+    const arm64_linux = b.addStaticLibrary("mqtt-c-arm64", null);
+    try includeCommon(arm64_linux);
+    arm64_linux.setTarget(std.zig.CrossTarget{
+        .cpu_arch = .aarch64,
+        .os_tag = .linux,
+    });
+    arm64_linux.install();
 
     const windows_step = b.step("windows", "Build for Windows");
     windows_step.dependOn(&windows.step);
 
-    const m1_mac_step = b.step("m1_mac", "Build for M1 Mac");
-    m1_mac_step.dependOn(&m1_mac.step);
+    const apple_silicon_mac_step = b.step("apple_silicon_mac", "Build for Apple Silicon Macs");
+    apple_silicon_mac_step.dependOn(&apple_silicon_mac.step);
 
-    const x64_mac_step = b.step("x64_mac", "Build for M1 Mac");
-    x64_mac_step.dependOn(&x64_mac.step);
+    const x86_64_mac_step = b.step("x86_64_mac", "Build for Intel Macs");
+    x86_64_mac_step.dependOn(&x86_64_mac.step);
+
+    const x86_64_linux_step = b.step("x86_64_linux", "Build for Linux");
+    x86_64_linux_step.dependOn(&x86_64_linux.step);
+
+    const arm64_linux_step = b.step("arm64_linux", "Build for ARM64 Linux");
+    arm64_linux_step.dependOn(&arm64_linux.step);
 }
 
 fn includeCommon(lib: *std.build.LibExeObjStep) !void {


### PR DESCRIPTION
Adds a `build.zig` file to be able to use the [Zig build system](https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html) to compile a static library for Windows (x86_64), macOS (Apple Silicon and Intel) and Linux (x86_64 and ARM64).

You can try it yourself by executing `zig build` in the repo root and following files should be created in `zig-out/lib`:
```
libmqtt-c-apple-silicon.a
libmqtt-c-arm64.a
libmqtt-c-mac-x64.a
libmqtt-c-x64.a
mqtt-c.lib
```